### PR TITLE
remove space between dns.command and dns.class in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -356,18 +356,18 @@ ecl.orchestration.v1 =
 	dpm_stack_show = eclcli.orchestration.v1.stack:ShowStack
 	dpm_stack_template_show = eclcli.orchestration.v1.stack:TemplateShowStack
 ecl.dns.v2 =
-    dns_zone_create = eclcli.dns.v2.zone: CreateZone
-    dns_zone_list = eclcli.dns.v2.zone: ListZone
-    dns_zone_delete = eclcli.dns.v2.zone: DeleteZone
-    dns_zone_show = eclcli.dns.v2.zone: ShowZone
-    dns_zone_update = eclcli.dns.v2.zone: UpdateZone
-    dns_nameserver_show = eclcli.dns.v2.nameserver: ShowNameServer
-    dns_recordset_create = eclcli.dns.v2.record: CreateRecordSet
-    dns_recordset_list = eclcli.dns.v2.record: ListRecordSet
-    dns_recordset_delete = eclcli.dns.v2.record: DeleteRecordSet
-    dns_recordset_multi_delete = eclcli.dns.v2.record: DeleteMultipleRecordSets
-    dns_recordset_show = eclcli.dns.v2.record: ShowRecordSet
-    dns_recordset_update = eclcli.dns.v2.record: UpdateRecordSet
+    dns_zone_create = eclcli.dns.v2.zone:CreateZone
+    dns_zone_list = eclcli.dns.v2.zone:ListZone
+    dns_zone_delete = eclcli.dns.v2.zone:DeleteZone
+    dns_zone_show = eclcli.dns.v2.zone:ShowZone
+    dns_zone_update = eclcli.dns.v2.zone:UpdateZone
+    dns_nameserver_show = eclcli.dns.v2.nameserver:ShowNameServer
+    dns_recordset_create = eclcli.dns.v2.record:CreateRecordSet
+    dns_recordset_list = eclcli.dns.v2.record:ListRecordSet
+    dns_recordset_delete = eclcli.dns.v2.record:DeleteRecordSet
+    dns_recordset_multi_delete = eclcli.dns.v2.record:DeleteMultipleRecordSets
+    dns_recordset_show = eclcli.dns.v2.record:ShowRecordSet
+    dns_recordset_update = eclcli.dns.v2.record:UpdateRecordSet
 
 
 [egg_info]


### PR DESCRIPTION
TO solve install bug `ValueError: ("EntryPoint must be in 'name=module:attrs [extras]' format", 'dns_zone_create = eclcli.dns.v2.zone: CreateZone')`