### PR TITLE
Change method from get to find for CLI command dns recordset show. 

### DIFF
--- a/eclcli/dns/v2/record.py
+++ b/eclcli/dns/v2/record.py
@@ -157,6 +157,11 @@ class ShowRecordSet(command.ShowOne):
             metavar="<record_id_or_name>",
             help="ID or name of the recordset you want to show.",
         )
+        parser.add_argument(
+            "--paginated",
+            action='store_true',
+            help="True or False (default is False). Set True for get more 100 items",
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -176,7 +181,7 @@ class ShowRecordSet(command.ShowOne):
             'updated_at',
             'links',
         ]
-        recordset = dns_client.find_recordset(parsed_args.zone_id, parsed_args.recordset_id_or_name)
+        recordset = dns_client.find_recordset(parsed_args.zone_id, parsed_args.recordset_id_or_name, paginated=parsed_args.paginated)
 
         return (row, utils.get_item_properties(recordset, row))
 

--- a/eclcli/dns/v2/record.py
+++ b/eclcli/dns/v2/record.py
@@ -153,9 +153,9 @@ class ShowRecordSet(command.ShowOne):
             help="ID of the zone which recordset you want to show belong to.",
         )
         parser.add_argument(
-            "recordset_id",
-            metavar="<record_id>",
-            help="ID of the recordset you want to show.",
+            "recordset_id_or_name",
+            metavar="<record_id_or_name>",
+            help="ID or name of the recordset you want to show.",
         )
         return parser
 
@@ -176,7 +176,7 @@ class ShowRecordSet(command.ShowOne):
             'updated_at',
             'links',
         ]
-        recordset = dns_client.get_recordset(parsed_args.zone_id, parsed_args.recordset_id)
+        recordset = dns_client.find_recordset(parsed_args.zone_id, parsed_args.recordset_id_or_name)
 
         return (row, utils.get_item_properties(recordset, row))
 


### PR DESCRIPTION
Change method from get to find for CLI command dns recordset show. Use ID or Name instead ID only