### PR TITLE
:wrench: IF-3839 Add parameters to dns recordset list command

### DIFF
--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -347,6 +347,31 @@ def validate_ipv4(text):
         raise exceptions.CommandError(msg % text)
     return text
 
+def validate_int_range(val, attr_name, min_value=None, max_value=None):
+    try:
+        if not isinstance(val, int):
+            int_val = int(val, 0)
+        else:
+            int_val = val
+        if ((min_value is None or min_value <= int_val) and
+                (max_value is None or int_val <= max_value)):
+            return
+    except (ValueError, TypeError):
+        pass
+
+    if min_value is not None and max_value is not None:
+        msg = "%s \"%s\" should be an integer [%i-%i]." % (attr_name.replace("_", "-"), val, min_value, max_value)
+    elif min_value is not None:
+        msg = "%s \"%s\" should be an integer greater than or equal to %i." \
+              % (attr_name.replace("_", "-"), val, min_value)
+    elif max_value is not None:
+        msg = "%s \"%s\" should be an integer smaller than or equal to %i." \
+              % (attr_name.replace("_", "-"), val, max_value)
+    else:
+        msg = "%s \"%s\" should be an integer." % (attr_name.replace("_", "-"), val)
+
+    raise exceptions.CommandError(msg)
+
 def parse_host_routes(text):
     if not text:
         return {}

--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -347,29 +347,18 @@ def validate_ipv4(text):
         raise exceptions.CommandError(msg % text)
     return text
 
-def validate_int_range(val, attr_name, min_value=None, max_value=None):
+def validate_int_range(text, min_val, max_val):
     try:
-        if not isinstance(val, int):
-            int_val = int(val, 0)
+        if not isinstance(text, int):
+            int_text = int(text, 0)
         else:
-            int_val = val
-        if ((min_value is None or min_value <= int_val) and
-                (max_value is None or int_val <= max_value)):
-            return
+            int_text = text
+        if min_val <= int_text <= max_val:
+            return int_text
     except (ValueError, TypeError):
         pass
 
-    if min_value is not None and max_value is not None:
-        msg = "%s \"%s\" should be an integer [%i-%i]." % (attr_name.replace("_", "-"), val, min_value, max_value)
-    elif min_value is not None:
-        msg = "%s \"%s\" should be an integer greater than or equal to %i." \
-              % (attr_name.replace("_", "-"), val, min_value)
-    elif max_value is not None:
-        msg = "%s \"%s\" should be an integer smaller than or equal to %i." \
-              % (attr_name.replace("_", "-"), val, max_value)
-    else:
-        msg = "%s \"%s\" should be an integer." % (attr_name.replace("_", "-"), val)
-
+    msg = "%s should be an integer [%i-%i]." % (text, min_val, max_val)
     raise exceptions.CommandError(msg)
 
 def parse_host_routes(text):

--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -358,7 +358,7 @@ def validate_int_range(text, min_val, max_val):
     if min_val <= int_text <= max_val:
         return int_text
 
-    msg = "%s should be an [%i-%i]." % (text, min_val, max_val)
+    msg = "%s is out of range[%i-%i]." % (text, min_val, max_val)
     raise exceptions.CommandError(msg)
 
 

--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -352,7 +352,7 @@ def validate_int_range(text, min_val, max_val):
     try:
         int_text = int(text)
     except ValueError:
-        msg = "%s should be an integer." % text
+        msg = "%s is not an integer." % text
         raise exceptions.CommandError(msg)
 
     if min_val <= int_text <= max_val:

--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -347,17 +347,20 @@ def validate_ipv4(text):
         raise exceptions.CommandError(msg % text)
     return text
 
+
 def validate_int_range(text, min_val, max_val):
     try:
         int_text = int(text)
-
-        if min_val <= int_text <= max_val:
-            return int_text
     except ValueError:
-        pass
+        msg = "%s should be an integer." % text
+        raise exceptions.CommandError(msg)
 
-    msg = "%s should be an integer [%i-%i]." % (text, min_val, max_val)
+    if min_val <= int_text <= max_val:
+        return int_text
+
+    msg = "%s should be an [%i-%i]." % (text, min_val, max_val)
     raise exceptions.CommandError(msg)
+
 
 def parse_host_routes(text):
     if not text:

--- a/eclcli/common/utils.py
+++ b/eclcli/common/utils.py
@@ -349,13 +349,11 @@ def validate_ipv4(text):
 
 def validate_int_range(text, min_val, max_val):
     try:
-        if not isinstance(text, int):
-            int_text = int(text, 0)
-        else:
-            int_text = text
+        int_text = int(text)
+
         if min_val <= int_text <= max_val:
             return int_text
-    except (ValueError, TypeError):
+    except ValueError:
         pass
 
     msg = "%s should be an integer [%i-%i]." % (text, min_val, max_val)

--- a/eclcli/dns/v2/record.py
+++ b/eclcli/dns/v2/record.py
@@ -189,12 +189,30 @@ class ListRecordSet(command.Lister):
             metavar="<zone_id>",
             help="ID of the zone which recordset you want to list belong to.",
         )
+        parser.add_argument(
+            "--limit",
+            metavar="<limit>",
+            type=int,
+            default=None,
+            help="The number of record sets that you want to display."
+                 "Values range from 1 to 500. (default=100)",
+        )
+        parser.add_argument(
+            "--marker",
+            metavar="<marker>",
+            default=None,
+            help="Specify the ID for the resource."
+                 "It is displayed from the next record of the specified ID.",
+        )
         return parser
 
     def take_action(self, parsed_args):
+        if parsed_args.limit is not None:
+            utils.validate_int_range(parsed_args.limit, "--limit", 1, 500)
+
         dns_client = self.app.eclsdk.conn.dns
 
-        recordsets = dns_client.recordsets(parsed_args.zone_id)
+        recordsets = dns_client.recordsets(parsed_args.zone_id, parsed_args.limit, parsed_args.marker)
 
         columns = [
             'id',

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six>=1.9.0 # MIT
 
 Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,!=2.4.0,>=1.3 # BSD
 cliff!=1.16.0,!=1.17.0,>=1.15.0 # Apache-2.0
-eclsdk>=0.0.8 # Apache-2.0
+eclsdk>=0.0.10 # Apache-2.0
 keystoneauth1<=3.4.0,>=2.1.0 # Apache-2.0
 openstacksdk<=0.13.0 # Apache-2.0
 os-client-config>=1.13.1 # Apache-2.0


### PR DESCRIPTION
We added a parameter to be passed to the API that displays a list of record sets associated with the zone of DNS and fixed it so that pagination can be done.

- Added a method to return an error message when common / utils.py has a numerical value out of the specified range.
-  Add parameters to CLI command

Please check whether the number of records specified by limit parameter is displayed or pagination by marker parameter is done.

Sample command
dns recordset list 2334e777-aa9c-435f-8de7-ea89b5e03301 --limit 10 --marker 46bd90a6-488b-493e-bd88-c319cf73df67