### PR TITLE
Fix description of CLI command argument

### DIFF
--- a/eclcli/network/v2/load_balancer.py
+++ b/eclcli/network/v2/load_balancer.py
@@ -248,7 +248,7 @@ class ResetPasswordLoadBalancer(command.ShowOne):
         parser = super(ResetPasswordLoadBalancer, self).get_parser(prog_name)
         parser.add_argument(
             'loadbalancer_id',
-            metavar="LOAD_BALANCER_PLAN_ID",
+            metavar="LOAD_BALANCER_ID",
             help="ID of Load Balancer to show."
         )
         parser.add_argument(


### PR DESCRIPTION
`ecl network load-balancer reset-password --help` を実行した際に、LOAD_BALANCER_IDと表示されるべきところがLOAD_BALANCER_PLAN_IDと表示されていたため修正。