### PR TITLE
fix param key of `update uefi` request body

### DIFF
--- a/eclcli/bare/v2/uefi.py
+++ b/eclcli/bare/v2/uefi.py
@@ -58,7 +58,8 @@ class UpdateUEFI(command.ShowOne):
             help="Name or ID of server",
         )
         parser.add_argument(
-            "--settings",
+            "--settings", '--setting',
+            dest='setting',
             metavar="<settings>",
             help="Dict object of settings to update. eg. {\"hoge\": "
                  "{\"value\": \"Disabled\"}, \"fuga\": {\"value\": \"Enabled\"}}",
@@ -69,8 +70,8 @@ class UpdateUEFI(command.ShowOne):
         bare_client = self.app.client_manager.bare
 
         body = {"uefi": {"setting": {}}}
-        if parsed_args.settings:
-            body['uefi']['setting'] = json.loads(parsed_args.settings)
+        if parsed_args.setting:
+            body['uefi']['setting'] = json.loads(parsed_args.setting)
 
         server_obj = utils.find_resource(bare_client.servers, parsed_args.server)
         bare_client.uefis.update(server_obj.id, body)

--- a/eclcli/bare/v2/uefi.py
+++ b/eclcli/bare/v2/uefi.py
@@ -70,7 +70,7 @@ class UpdateUEFI(command.ShowOne):
 
         body = {"uefi": {"setting": {}}}
         if parsed_args.settings:
-            body['uefi']['settings'] = json.loads(parsed_args.settings)
+            body['uefi']['setting'] = json.loads(parsed_args.settings)
 
         server_obj = utils.find_resource(bare_client.servers, parsed_args.server)
         bare_client.uefis.update(server_obj.id, body)


### PR DESCRIPTION
resolve #79 

I fixed request body of `Update UEFI` for baremetal server.

before:
```
$ ecl --debug baremetal uefi update XXX --settings '{"SataSecureErase":{"value":"Enabled"}}'
START with options: ['--debug', 'baremetal', 'uefi', 'update', 'XXX', '--settings', '{"SataSecureErase":{"value":"Enabled"}}']
: (snip)
REQ: curl -g -i -X PUT https://baremetal-server-jp1-ecl.api.ntt.com/v2/tenant_id/servers/XXX/uefi -H "Accept: application/json" -H "X-Auth-Token: {SHA1}XXX" -H "User-Agent: python-bearclient" -H "Content-Type: application/json" -d '{"uefi": {"setting": {}, "settings": {"SataSecureErase": {"value": "Enabled"}}}}'
```

after:
```
$ ecl --debug baremetal uefi update XXX --settings '{"SataSecureErase":{"value":"Enabled"}}'
START with options: ['--debug', 'baremetal', 'uefi', 'update', 'XXX', '--settings', '{"SataSecureErase":{"value":"Enabled"}}']
: (snip)
REQ: curl -g -i -X PUT https://baremetal-server-jp1-ecl.api.ntt.com/v2/tenant_id/servers/XXX/uefi -H "Accept: application/json" -H "X-Auth-Token: {SHA1}XXX" -H "User-Agent: python-bearclient" -H "Content-Type: application/json" -d '{"uefi": {"setting": {"SataSecureErase": {"value": "Enabled"}}}}'
```