### PR TITLE
Fix eclsdk version to 0.0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six>=1.9.0 # MIT
 Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,!=2.4.0,>=1.3 # BSD
 cliff!=1.16.0,!=1.17.0,>=1.15.0 # Apache-2.0
 cryptography>=2.9.2
-eclsdk>=0.0.18 # Apache-2.0
+eclsdk==0.0.18 # Apache-2.0
 future>=0.17.1 # MIT
 keystoneauth1<=3.4.0,>=2.1.0 # Apache-2.0
 openstacksdk<=0.13.0 # Apache-2.0


### PR DESCRIPTION
MSS v1 APIをサポートする最後のeclcliバージョンを作成するために、eclsdkを0.0.18に固定しました。
変更内容のレビューをお願いします。