### PR TITLE
:bug: IF-9147 Fix Specifying Fixed IP Address of Tenant Connection

### DIFF
--- a/eclcli/provider_connectivity/v1/tenant_connection.py
+++ b/eclcli/provider_connectivity/v1/tenant_connection.py
@@ -131,9 +131,10 @@ class CreateTenantConnection(command.ShowOne):
         parser.add_argument(
             '--fixed-ip',
             action='append',
-            type=utils.parse_tags,
-            metavar='<IP Address>',
+            type=utils.parse_fixed_ips,
+            metavar='<subnet_id,ipv4>|<ipv4>',
             help="Fixed ip address of tenant connection to create. "
+                 "subnet_id,ipv4 or ipv4 format. "
                  "You can repeat this option."
         )
 
@@ -167,7 +168,7 @@ class CreateTenantConnection(command.ShowOne):
         if parsed_args.segmentation_id:
             attachment_opts['segmentation_id'] = parsed_args.segmentation_id
         if parsed_args.fixed_ip:
-            attachment_opts['fixed_ip'] = parsed_args.fixed_ip
+            attachment_opts['fixed_ips'] = parsed_args.fixed_ip
 
         if len(attachment_opts.keys()) > 0:
             body['attachment_opts'] = attachment_opts

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eclcli
-version = 3.3.0
+version = 3.3.1
 summary = CLI for Enterprise Cloud 2.0
 description-file =
     README.rst


### PR DESCRIPTION
* eclcli/provider_connectivity/v1/tenant_connection.py
  - attachment_opts['fixed_ip'] のキーを fixed_ips （複数形）に修正
  - utils.parse_tags 関数を utils.parse_fixed_ips関数に修正
  - 引数の説明を修正