### PR TITLE
:bug: Fix bug in booting VM from volume IF-11775

### DIFF
--- a/eclcli/compute/v2/server.py
+++ b/eclcli/compute/v2/server.py
@@ -420,7 +420,7 @@ class CreateServer(command.ShowOne):
             volume = utils.find_resource(
                 volume_client.volumes,
                 parsed_args.volume,
-            ).id
+            )
 
         # Lookup parsed_args.flavor
         flavor = utils.find_resource(compute_client.flavors,
@@ -458,7 +458,11 @@ class CreateServer(command.ShowOne):
         if volume:
             # When booting from volume, for now assume no other mappings
             # This device value is likely KVM-specific
-            block_device_mapping = {'vda': volume}
+            if hasattr(volume, 'volume_image_metadata') and \
+                    volume.volume_image_metadata.get('root_device_name') == 'sda':
+                block_device_mapping = {'sda': volume.id}
+            else:
+                block_device_mapping = {'vda': volume.id}
         else:
             for dev_map in parsed_args.block_device_mapping:
                 dev_key, dev_vol = dev_map.split('=', 1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eclcli
-version = 3.4.0
+version = 3.4.1
 summary = CLI for Enterprise Cloud 2.0
 description-file =
     README.rst


### PR DESCRIPTION
### Overview
Fixed a bug that caused an error when launching a VM with a Windows Server 2019 volume specified.

### Detail
- eclcli/image/v2/image.py
    - When a volume is specified, if the value of root_device_name is "sda", "sda" is specified for device_name.
- setup.cfg
    - Change version value.
