### PR TITLE
✨  VNF-2455 add idle-timeout parameter for mlb/v1/mlb_policy.py

### DIFF
--- a/eclcli/mlb/v1/mlb_policy.py
+++ b/eclcli/mlb/v1/mlb_policy.py
@@ -169,6 +169,7 @@ class CreatePolicy(command.ShowOne):
         parser.add_argument(
             '--idle-timeout',
             metavar='<idle-timeout>',
+            type=int,
             help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
         )
 
@@ -393,6 +394,7 @@ class CreateStagedPolicyConfiguration(command.ShowOne):
         parser.add_argument(
             '--idle-timeout',
             metavar='<idle-timeout>',
+            type=int,
             help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
         )
 
@@ -540,6 +542,7 @@ class UpdateStagedPolicyConfiguration(command.ShowOne):
         parser.add_argument(
             '--idle-timeout',
             metavar='<idle-timeout>',
+            type=int,
             help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
         )
 

--- a/eclcli/mlb/v1/mlb_policy.py
+++ b/eclcli/mlb/v1/mlb_policy.py
@@ -21,6 +21,7 @@ ROWS_FOR_SHOW = [
     'Tenant ID',
     'Algorithm',
     'Persistence',
+    'Idle timeout',
     'Sorry page url',
     'Source NAT',
     'Certificate ID',
@@ -38,6 +39,7 @@ ROWS_FOR_CHANGES = [
 ROWS_FOR_SHOW_STAGED = [
     'Algorithm',
     'Persistence',
+    'Idle timeout',
     'Sorry page url',
     'Source NAT',
     'Certificate ID',
@@ -67,6 +69,7 @@ class ListPolicy(command.Lister):
             'Load Balancer ID',
             'Algorithm',
             'Persistence',
+            'Idle timeout',
             'Sorry page url',
             'Source NAT',
             'Certificate ID',
@@ -164,6 +167,12 @@ class CreatePolicy(command.ShowOne):
         )
 
         parser.add_argument(
+            '--idle-timeout',
+            metavar='<idle-timeout>',
+            help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
+        )
+
+        parser.add_argument(
             '--sorry-page-url',
             metavar='<sorry-page-url>',
             help=_('URL of the sorry page to which accesses are redirected '
@@ -239,6 +248,7 @@ class CreatePolicy(command.ShowOne):
             tags=tags,
             algorithm=parsed_args.algorithm,
             persistence=parsed_args.persistence,
+            idle_timeout=parsed_args.idle_timeout,
             sorry_page_url=parsed_args.sorry_page_url,
             certificate_id=parsed_args.certificate_id,
             source_nat=parsed_args.source_nat,
@@ -381,6 +391,12 @@ class CreateStagedPolicyConfiguration(command.ShowOne):
         )
 
         parser.add_argument(
+            '--idle-timeout',
+            metavar='<idle-timeout>',
+            help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
+        )
+
+        parser.add_argument(
             '--sorry-page-url',
             metavar='<sorry-page-url>',
             help=_('URL of the sorry page to which accesses are redirected '
@@ -437,6 +453,7 @@ class CreateStagedPolicyConfiguration(command.ShowOne):
             parsed_args.policy,
             algorithm=parsed_args.algorithm,
             persistence=parsed_args.persistence,
+            idle_timeout=parsed_args.idle_timeout,
             sorry_page_url=parsed_args.sorry_page_url,
             certificate_id=parsed_args.certificate_id,
             source_nat=parsed_args.source_nat,
@@ -521,6 +538,12 @@ class UpdateStagedPolicyConfiguration(command.ShowOne):
         )
 
         parser.add_argument(
+            '--idle-timeout',
+            metavar='<idle-timeout>',
+            help=_('The duration (in seconds) during which a session is allowed to remain inactive'),
+        )
+
+        parser.add_argument(
             '--sorry-page-url',
             metavar='<sorry-page-url>',
             help=_('URL of the sorry page to which accesses are redirected '
@@ -577,6 +600,7 @@ class UpdateStagedPolicyConfiguration(command.ShowOne):
             parsed_args.policy,
             algorithm=parsed_args.algorithm,
             persistence=parsed_args.persistence,
+            idle_timeout=parsed_args.idle_timeout,
             sorry_page_url=parsed_args.sorry_page_url,
             certificate_id=parsed_args.certificate_id,
             source_nat=parsed_args.source_nat,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eclcli
-version = 3.4.1
+version = 3.5.0
 summary = CLI for Enterprise Cloud 2.0
 description-file =
     README.rst


### PR DESCRIPTION
[eclcli を mLB Day 3 に対応させる](https://nttcom.atlassian.net/browse/VNF-2455)

- mlb policy のパラメータとして idle timeout を追加しました