### PR TITLE
feat: VNF-3110 add initial_config to create_virtual_network_appliance

### DIFF
--- a/eclcli/mlb/v1/mlb_certificate.py
+++ b/eclcli/mlb/v1/mlb_certificate.py
@@ -273,8 +273,8 @@ class UploadCertificate(command.Command):
             try:
                 with open(content_path, 'rb') as f:
                     certificate_content = base64.b64encode(f.read()).decode()
-            except IOError as e:
-                msg = "content file %s not found: %s"
+            except OSError as e:
+                msg = "Failed to open/read content file %s: %s"
                 raise exceptions.CommandError(msg % (content_path, e))
 
         client.upload_certificate(

--- a/eclcli/vnf/v1/virtual_network_appliance.py
+++ b/eclcli/vnf/v1/virtual_network_appliance.py
@@ -300,8 +300,8 @@ class CreateVirtualNetworkAppliance(command.ShowOne):
             try:
                 with open(config_path, 'rb') as f:
                     config_data = base64.b64encode(f.read()).decode()
-            except IOError as e:
-                msg = "config file %s not found: %s"
+            except OSError as e:
+                msg = "Failed to open/read config file %s: %s"
                 raise exceptions.CommandError(msg % (config_path, e))
 
             initial_config_object = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six>=1.9.0 # MIT
 Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,!=2.4.0,>=1.3 # BSD
 cliff!=1.16.0,!=1.17.0,>=1.15.0,<3.7.0 # Apache-2.0
 cryptography>=2.9.2
-eclsdk>=1.5.0 # Apache-2.0
+eclsdk>=1.6.0 # Apache-2.0
 future>=0.17.1 # MIT
 keystoneauth1<=3.4.0,>=2.1.0 # Apache-2.0
 openstacksdk<=0.13.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eclcli
-version = 4.4.0
+version = 4.5.0
 summary = CLI for Enterprise Cloud 2.0
 description-file =
     README.rst


### PR DESCRIPTION
- vnaに関して初期config投入用のパラメータを追加しました
  - (e.g., `--initial-config format=set,data=/path/to/config`)
- mLBのファイル操作周りのエラーハンドリングを修正
- setup.cfgを4.4.0 -> 4.5.0へversion up
