### PR TITLE
:sparkles: Remove unnecessary parameter from tenant-connection-request create IF-13484

### DIFF
--- a/eclcli/provider_connectivity/v1/tenant_connection_request.py
+++ b/eclcli/provider_connectivity/v1/tenant_connection_request.py
@@ -72,24 +72,10 @@ class CreateTenantConnectionRequest(command.ShowOne):
                        self).get_parser(prog_name)
 
         parser.add_argument(
-            '--keystone-user-id',
-            metavar='<KEYSTONE USER ID>',
-            help='Keystone user ID of tenant connection request',
-            required=False,
-        )
-
-        parser.add_argument(
             '--network-id',
             metavar='<NETWORK ID>',
             help='Network ID of tenant connection request',
             required=True,
-        )
-
-        parser.add_argument(
-            '--tenant-id',
-            metavar='<TENANT ID>',
-            help='Tenant ID of owner of tenant connection request',
-            required=False,
         )
 
         parser.add_argument(
@@ -125,10 +111,8 @@ class CreateTenantConnectionRequest(command.ShowOne):
         client = self.app.eclsdk.conn.provider_connectivity
 
         body = {
-            'keystone_user_id': parsed_args.keystone_user_id,
             'network_id': parsed_args.network_id,
             'tenant_id_other': parsed_args.tenant_id_other,
-            'tenant_id': parsed_args.tenant_id,
         }
         if parsed_args.name:
             body['name'] = parsed_args.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six>=1.9.0 # MIT
 Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,!=2.4.0,>=1.3 # BSD
 cliff!=1.16.0,!=1.17.0,>=1.15.0,<3.7.0 # Apache-2.0
 cryptography>=2.9.2
-eclsdk>=1.4.0 # Apache-2.0
+eclsdk>=1.5.0 # Apache-2.0
 future>=0.17.1 # MIT
 keystoneauth1<=3.4.0,>=2.1.0 # Apache-2.0
 openstacksdk<=0.13.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eclcli
-version = 4.2.0
+version = 4.3.0
 summary = CLI for Enterprise Cloud 2.0
 description-file =
     README.rst


### PR DESCRIPTION
### Overview
* Remove `--keystone-user-id`, `--tenant-id` parameter from `icc tenant-connection-request create` command

### Detail
* eclcli/provider_connectivity/v1/tenant_connection_request.py
  - Remove unnecessary `--keystone-user-id`, `--tenant-id` parameter
* requirements.txt
  - Update version number of ECL SDK
* setup.cfg
  - Version up